### PR TITLE
Re-instate missing updates from 1.2.0

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -1,6 +1,8 @@
 <?php
 namespace ZF\HttpCache;
 
+use Zend\Loader\StandardAutoloader;
+
 class Module
 {
     /**
@@ -8,7 +10,7 @@ class Module
      */
     public function getAutoloaderConfig()
     {
-        return [Zend\Loader\StandardAutoloader::class => ['namespaces' => [
+        return [StandardAutoloader::class => ['namespaces' => [
             __NAMESPACE__ => __DIR__.'/src/',
         ]]];
     }

--- a/Module.php
+++ b/Module.php
@@ -1,7 +1,12 @@
 <?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
 namespace ZF\HttpCache;
 
-use Zend\Loader\StandardAutoloader;
+use Zend\Mvc\MvcEvent;
 
 class Module
 {
@@ -10,7 +15,9 @@ class Module
      */
     public function getAutoloaderConfig()
     {
-        return [StandardAutoloader::class => ['namespaces' => [
+        // Using string class name, as this method might not get called,
+        // allowing us to remove a dependency.
+        return ['Zend\Loader\StandardAutoloader' => ['namespaces' => [
             __NAMESPACE__ => __DIR__.'/src/',
         ]]];
     }
@@ -23,7 +30,7 @@ class Module
         return include __DIR__.'/config/module.config.php';
     }
 
-    public function onBootstrap(\Zend\Mvc\MvcEvent $e)
+    public function onBootstrap(MvcEvent $e)
     {
         $app = $e->getApplication();
         $em  = $app->getEventManager();

--- a/composer.json
+++ b/composer.json
@@ -48,12 +48,12 @@
         "php": "^5.5|^7.0",
         "zendframework/zend-eventmanager": "~2.5",
         "zendframework/zend-http": "~2.5",
-        "zendframework/zend-loader": "~2.5",
         "zendframework/zend-mvc": "~2.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",
-        "squizlabs/php_codesniffer": "^2.3.1"
+        "squizlabs/php_codesniffer": "^2.3.1",
+        "zendframework/zend-loader": "~2.5"
     },
     "support": {
         "email": "apigility-users@zend.com",

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
 use ZF\HttpCache\HttpCacheListener;
 use ZF\HttpCache\HttpCacheListenerFactory;
 

--- a/src/HttpCacheListener.php
+++ b/src/HttpCacheListener.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
 namespace ZF\HttpCache;
 
 use Zend\EventManager\EventManagerInterface;
@@ -116,15 +121,14 @@ class HttpCacheListener extends AbstractListenerAggregate
             return;
         }
 
-        if (! empty($this->config['controllers'])) {
-            $cacheConfig = $this->config['controllers'];
-        } else {
+        if (empty($this->config['controllers'])) {
             $this->cacheConfig = [];
-
             return;
         }
 
-        $controller = $e->getRouteMatch()
+        $cacheConfig = $this->config['controllers'];
+        $controller  = $e
+            ->getRouteMatch()
             ->getParam('controller');
 
         if (! empty($cacheConfig[$controller])) {
@@ -142,7 +146,6 @@ class HttpCacheListener extends AbstractListenerAggregate
             $controllerConfig = $cacheConfig['*'];
         } else {
             $this->cacheConfig = [];
-
             return;
         }
 
@@ -158,7 +161,6 @@ class HttpCacheListener extends AbstractListenerAggregate
             $methodConfig = $cacheConfig['*']['*'];
         } else {
             $this->cacheConfig = [];
-
             return;
         }
 
@@ -174,7 +176,6 @@ class HttpCacheListener extends AbstractListenerAggregate
     public function setCacheConfig(array $cacheConfig)
     {
         $this->cacheConfig = $cacheConfig;
-
         return $this;
     }
 
@@ -186,7 +187,8 @@ class HttpCacheListener extends AbstractListenerAggregate
     {
         if (! empty($this->cacheConfig['cache-control']['value'])
             && (! $headers->has('cache-control')
-            || ! empty($this->cacheConfig['cache-control']['override']))
+                || ! empty($this->cacheConfig['cache-control']['override'])
+            )
         ) {
             $cacheControl = Header\CacheControl::fromString(
                 "Cache-Control: {$this->cacheConfig['cache-control']['value']}"
@@ -206,7 +208,6 @@ class HttpCacheListener extends AbstractListenerAggregate
     public function setConfig(array $config)
     {
         $this->config = $config;
-
         return $this;
     }
 
@@ -217,18 +218,17 @@ class HttpCacheListener extends AbstractListenerAggregate
     public function setExpires(Headers $headers)
     {
         if (! empty($this->cacheConfig['expires']['value'])
-            and (! $headers->has('expires')
-            || ! empty($this->cacheConfig['expires']['override']))
+            && (! $headers->has('expires')
+                || ! empty($this->cacheConfig['expires']['override'])
+            )
         ) {
             $expires = new Header\Expires();
             try {
                 $expires->setDate($this->cacheConfig['expires']['value']);
-            } catch (\Zend\Http\Header\Exception\InvalidArgumentException $e) {
-                if ($headers->has('date')) {
-                    $date = $headers->get('date')->date();
-                } else {
-                    $date = "@{$_SERVER['REQUEST_TIME']}";
-                }
+            } catch (Header\Exception\InvalidArgumentException $e) {
+                $date = $headers->has('date')
+                    ? $headers->get('date')->date()
+                    : sprintf('@%s', $_SERVER['REQUEST_TIME']);
                 $expires->setDate($date);
             }
 
@@ -245,8 +245,9 @@ class HttpCacheListener extends AbstractListenerAggregate
     public function setPragma(Headers $headers)
     {
         if (! empty($this->cacheConfig['pragma']['value'])
-            and (! $headers->has('pragma')
-            || ! empty($this->cacheConfig['pragma']['override']))
+            && (! $headers->has('pragma')
+                || ! empty($this->cacheConfig['pragma']['override'])
+            )
         ) {
             $pragma = new Header\Pragma($this->cacheConfig['pragma']['value']);
             $headers->addHeader($pragma);
@@ -262,8 +263,9 @@ class HttpCacheListener extends AbstractListenerAggregate
     public function setVary(Headers $headers)
     {
         if (! empty($this->cacheConfig['vary']['value'])
-            and (! $headers->has('vary')
-            || ! empty($this->cacheConfig['vary']['override']))
+            && (! $headers->has('vary')
+                || ! empty($this->cacheConfig['vary']['override'])
+            )
         ) {
             $vary = new Header\Vary($this->cacheConfig['vary']['value']);
             $headers->addHeader($vary);

--- a/src/HttpCacheListenerFactory.php
+++ b/src/HttpCacheListenerFactory.php
@@ -1,20 +1,27 @@
 <?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
 namespace ZF\HttpCache;
 
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
-
-class HttpCacheListenerFactory implements FactoryInterface
+class HttpCacheListenerFactory
 {
     /**
-     * @param  ServiceLocatorInterface $services
+     * Factory for producing an HttpCacheListener.
+     *
+     * Duck-types on the $container type to allow usage with
+     * zend-servicemanager versions 2.5+ and 3.0+.
+     *
+     * @param  \Interop\Container\ContainerInterface|\Zend\ServiceManagerServiceLocatorInterface $container
      * @return HttpCacheListener
      */
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    public function createService($container)
     {
         $config = [];
-        if ($serviceLocator->has('Config')) {
-            $config = $serviceLocator->get('Config');
+        if ($container->has('config')) {
+            $config = $container->get('config');
             if (isset($config['zf-http-cache'])) {
                 $config = $config['zf-http-cache'];
             }


### PR DESCRIPTION
1.2.0 was supposed to have full forward compat with both zend-eventmanager and zend-servicemanager v3.0, and also was to have updates that included:

- file-level license docblocks
- appropriate imports across all files
- nested conditional indentation fixes

Somehow, these went AWOL during the merges, so this patch re-instates them.