### PR TITLE
Ensure factory actually works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#6](https://github.com/zfcampus/zf-http-cache/pull/6) fixes the
+  `HttpCacheListenerFactory` to rename the `createService()` to `__invoke()`,
+  as originally intended in #4.
 
 ## 1.2.1 - 2015-11-10
 

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "zendframework/zend-mvc": "~2.5"
     },
     "require-dev": {
+        "container-interop/container-interop": "^1.1",
         "phpunit/phpunit": "~4.7",
         "squizlabs/php_codesniffer": "^2.3.1",
         "zendframework/zend-loader": "~2.5"

--- a/src/HttpCacheListenerFactory.php
+++ b/src/HttpCacheListenerFactory.php
@@ -17,7 +17,7 @@ class HttpCacheListenerFactory
      * @param  \Interop\Container\ContainerInterface|\Zend\ServiceManagerServiceLocatorInterface $container
      * @return HttpCacheListener
      */
-    public function createService($container)
+    public function __invoke($container)
     {
         $config = [];
         if ($container->has('config')) {

--- a/test/HttpCacheListenerFactoryTest.php
+++ b/test/HttpCacheListenerFactoryTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\HttpCache;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use ZF\HttpCache\HttpCacheListener;
+use ZF\HttpCache\HttpCacheListenerFactory;
+
+class HttpCacheListenerFactoryTest extends TestCase
+{
+    public function testFactoryCreatesListenerWhenNoConfigServiceIsPresent()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('config')->willReturn(false);
+
+        $factory  = new HttpCacheListenerFactory();
+        $listener = $factory($container->reveal());
+        $this->assertInstanceOf(HttpCacheListener::class, $listener);
+    }
+
+    public function testFactoryWillUseConfigServiceWhenPresentToCreateListener()
+    {
+        $config = [
+            'zf-http-cache' => [
+                'enable'                => true,
+                'controllers'           => [],
+                'http_codes_black_list' => [ 201, 404 ],
+                'regex_delimiter'       => '#',
+            ],
+        ];
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+
+        $factory  = new HttpCacheListenerFactory();
+        $listener = $factory($container->reveal());
+        $this->assertInstanceOf(HttpCacheListener::class, $listener);
+        $this->assertAttributeSame($config['zf-http-cache'], 'config', $listener);
+    }
+}


### PR DESCRIPTION
When updating the factory for v3, I forgot to change the method name from `createService()` to `__invoke()`. To ensure the factory properly works going forward, this patch also adds a test for the factory, using a container-interop mock instance.