### PR TITLE
Route name, controller/action, controller based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,13 @@ The `config/module.config.php` file contains a self-explanative example of confi
 
 #### Key: `controllers`
 
-The `controllers` key is utilized for mapping a combination of a controller and a HTTP method (see below) to a cache header configuration.
+The `controllers` key is utilized for mapping (case sensitive) either 
+- a route name
+- or a concatenated `controller::action`
+- or a controller
+- or a regexp 
+- or a wildcard
+and a HTTP method (see below) to a cache header configuration.
 
 Example:
 
@@ -80,7 +86,11 @@ Example:
 
 ##### Key: `<controller>` 
 
-Either a controller name (as returned by `Zend\Mvc\MvcEvent::getRouteMatch()->getParam('controller')`, case-sensitive) or a wildcard.
+Either 
+- a concatenation of `$controller::$action` 
+- or a controller name (as returned by `Zend\Mvc\MvcEvent::getRouteMatch()->getParam('controller')`, case-sensitive) 
+- or a regexp (see `<regex_delimiter>` key)
+- or a wildcard
 
 A wildcard stands for all the non-specified controllers.
 

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -57,7 +57,7 @@ return [
     //        /*
     //         * Regular configuration.
     //         */
-    //        'home' => [ // controller name
+    //        'home::index' => [ // route name
     //            'get' => [ // Http method (wildcard '*' supported as whatever method)
     //                /*
     //                 * General HTTP caching theory: http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
@@ -91,6 +91,15 @@ return [
     //                    'value'    => 'accept-encoding, x-requested-with',
     //                ],
     //            ],
+    //        ],
+    //        'index::index' => [ // controller / action names
+    //            'get' => [...],
+    //        ],
+    //        'index' => [ // controller name
+    //            'get' => [...],
+    //        ],
+    //        '~.*::index~' => [ // regex
+    //            'get' => [...],
     //        ],
     //    ],
     //

--- a/src/HttpCacheListener.php
+++ b/src/HttpCacheListener.php
@@ -150,10 +150,9 @@ class HttpCacheListener extends AbstractListenerAggregate
         } elseif (! empty($this->config['regex_delimiter'])) {
             foreach ($cacheConfig as $key => $config) {
                 if (substr($key, 0, 1) === $this->config['regex_delimiter']) {
-                    if (
-                        preg_match($key, $routeName)
-                        or preg_match($key, "$controller::$action")
-                        or preg_match($key, $controller)
+                    if (preg_match($key, $routeName)
+                        || preg_match($key, "$controller::$action")
+                        || preg_match($key, $controller)
                     ) {
                         $controllerConfig = $config;
                         break;

--- a/src/HttpCacheListener.php
+++ b/src/HttpCacheListener.php
@@ -137,7 +137,7 @@ class HttpCacheListener extends AbstractListenerAggregate
          * Searches, case sensitive, in this very order:
          * a matching route name in config
          * if not found, a matching "controller::action" name
-         * if not found, a matching "controller::action" name
+         * if not found, a matching "controller" name
          * if not found, a matching regex
          * if not found, a wildcard (default)
          */

--- a/src/HttpCacheListener.php
+++ b/src/HttpCacheListener.php
@@ -127,16 +127,34 @@ class HttpCacheListener extends AbstractListenerAggregate
         }
 
         $cacheConfig = $this->config['controllers'];
-        $controller  = $e
-            ->getRouteMatch()
-            ->getParam('controller');
+        $routeMatch  = $e->getRouteMatch();
 
-        if (! empty($cacheConfig[$controller])) {
+        $action      = $routeMatch->getParam('action');
+        $controller  = $routeMatch->getParam('controller');
+        $routeName   = $routeMatch->getMatchedRouteName();
+
+        /*
+         * Searches, case sensitive, in this very order:
+         * a matching route name in config
+         * if not found, a matching "controller::action" name
+         * if not found, a matching "controller::action" name
+         * if not found, a matching regex
+         * if not found, a wildcard (default)
+         */
+        if (! empty($cacheConfig[$routeName])) {
+            $controllerConfig = $cacheConfig[$routeName];
+        } elseif (! empty($cacheConfig["$controller::$action"])) {
+            $controllerConfig = $cacheConfig["$controller::$action"];
+        } elseif (! empty($cacheConfig[$controller])) {
             $controllerConfig = $cacheConfig[$controller];
         } elseif (! empty($this->config['regex_delimiter'])) {
             foreach ($cacheConfig as $key => $config) {
                 if (substr($key, 0, 1) === $this->config['regex_delimiter']) {
-                    if (preg_match($key, preg_quote($controller, $this->config['regex_delimiter']))) {
+                    if (
+                        preg_match($key, $routeName)
+                        or preg_match($key, "$controller::$action")
+                        or preg_match($key, $controller)
+                    ) {
                         $controllerConfig = $config;
                         break;
                     }


### PR DESCRIPTION
Allowing to use zf-http-cache with ZF2 by making configuration either route or controller/action or only controller based.