### PR TITLE
Add compatibility with ZF3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,9 +46,10 @@
     ],
     "require": {
         "php": "^5.5|^7.0",
-        "zendframework/zend-eventmanager": "~2.5",
+        "zendframework/zend-eventmanager": "~2.5|~3.0",
         "zendframework/zend-http": "~2.5",
-        "zendframework/zend-mvc": "~2.5"
+        "zendframework/zend-mvc": "~2.5|~3.0",
+        "zendframework/zend-router": "~3.0"
     },
     "require-dev": {
         "container-interop/container-interop": "^1.1",

--- a/test/HttpCacheListenerTest.php
+++ b/test/HttpCacheListenerTest.php
@@ -4,7 +4,7 @@ namespace ZFTest\HttpCache;
 use Zend\Http\Request as HttpRequest;
 use Zend\Http\Response as HttpResponse;
 use Zend\Mvc\MvcEvent;
-use Zend\Mvc\Router\RouteMatch;
+use Zend\Router\RouteMatch;
 use ZF\HttpCache\HttpCacheListener;
 
 class HttpCacheListenerTest extends \PHPUnit_Framework_TestCase
@@ -621,7 +621,7 @@ class HttpCacheListenerTest extends \PHPUnit_Framework_TestCase
         $date   = new \DateTime($headers['Expires']);
         $exDate = new \DateTime($exHeaders['Expires']);
 
-        $this->assertEquals($exDate, $date, '', 2);
+        $this->assertEquals($exDate, $date, '', 3);
     }
 
     /**


### PR DESCRIPTION
By adding the or statement for zend-eventmanager and zend-mvc it allows to be installed with ZF3.
However Zend-router has become a separate component.

Delta change (2 => 3) is needed to make the original test run on my local setup.

If any change is needed please let me know. Both PHPUnit and PHPCS ran without errors.